### PR TITLE
samples/bluetooth/central_dfu_smp: Fix missing cbor functions

### DIFF
--- a/samples/bluetooth/central_dfu_smp/CMakeLists.txt
+++ b/samples/bluetooth/central_dfu_smp/CMakeLists.txt
@@ -12,4 +12,3 @@ project(NONE)
 FILE(GLOB app_sources src/*.c)
 
 target_sources(app PRIVATE ${app_sources})
-target_link_libraries(app PRIVATE TINYCBOR)


### PR DESCRIPTION
Commits:
 08c8dc7e 		to zephyrproject-rtos/zephyr
 c5741cc9...40daca97	to zephyrproject-rtos/tinycbor
repositories have removed some functionalities from Tinycbor library that
have that has been in used in the sample. This patch fixes the problem.

Signed-off-by: Dominik Ermel <dominik.ermel@nordicsemi.no>